### PR TITLE
bump deps, and allow auto minor versions for deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,19 +22,19 @@
     "api"
   ],
   "dependencies": {
-    "accounting": "0.4.1",
-    "backbone": "1.1.2",
-    "bluebird": "~2.9.27",
-    "debug": "~2.2.0",
-    "express": "~4.12.4",
-    "lodash": "~3.9.3",
-    "moment": "~2.10.3",
-    "mongodb": "~2.0.33",
-    "mongodb-objectid-helper": "0.2.0",
-    "request": "~2.57.0",
-    "urlsafe-base64": "1.0.0",
-    "uuid": "~2.0.1",
-    "xml2js": "0.4.9"
+    "accounting": "^0.4.1",
+    "backbone": "^1.2.1",
+    "bluebird": "^2.9.30",
+    "debug": "^2.2.0",
+    "express": "^4.13.0",
+    "lodash": "^3.10.0",
+    "moment": "^2.10.3",
+    "mongodb": "^2.0.35",
+    "mongodb-objectid-helper": "^0.2.0",
+    "request": "^2.58.0",
+    "urlsafe-base64": "^1.0.0",
+    "uuid": "^2.0.1",
+    "xml2js": "^0.4.9"
   },
   "devDependencies": {
     "chai": "*",


### PR DESCRIPTION
Ran the `api` unit tests and integration tests and both pass

I'll be bumping `muni` by a `minor` version after this merge
### CHANGELOGS

https://github.com/strongloop/express/blob/master/History.md
https://github.com/lodash/lodash/wiki/Changelog
https://github.com/strongloop/express/blob/master/History.md
https://github.com/mongodb/node-mongodb-native/blob/2.0/HISTORY.md
