### PR TITLE
Change the way the mongodb driver sets options

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "kerberos": "0.0.18",
     "lodash": "^4.1.0",
     "moment": "^2.11.1",
-    "mongodb": "^2.0.35",
+    "mongodb": "^2.1.4",
     "mongodb-objectid-helper": "^1.0.1",
     "request": "^2.69.0",
     "urlsafe-base64": "^1.0.0",


### PR DESCRIPTION
The old way used to generate a URL query string which didn't allow setting advanced options like SSL.
