### PR TITLE
Catch errors from createIndex

### DIFF
--- a/model.js
+++ b/model.js
@@ -1004,7 +1004,13 @@ module.exports = Backbone.Model.extend({
           this.urlRoot,
           index.keys,
           options
-        )
+        ).bind(this).catch(function(err) {
+          debug.warn(
+            '#ensureIndex [%s]: %s',
+            this.urlRoot,
+            err
+          );
+        })
       );
     }.bind(this));
 


### PR DESCRIPTION
Errors from mismatching indexes such as `MongoError: Index with name: slug_1 already exists with different options` caused the first request of that collection to fail.
