### PR TITLE
Updated mongo driver to changed output format of mapReduce in the new node-mongodb-native driver

### DIFF
--- a/mongo.js
+++ b/mongo.js
@@ -550,7 +550,7 @@ _.assign(Mongo.prototype, {
       JSON.stringify(options)
     );
     return this._collection(collectionName).bind(this).then(function(collection) {
-      return collection.aggregate(pipeline, options);
+      return collection.aggregate(pipeline, options).toArray();
     }).then(function(result) {
       return this.uncast(result);
     }).then(function(result) {


### PR DESCRIPTION
#### Map Reduce

http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#mapReduce

See the example called `// A simple map reduce example using the inline output type on MongoDB > 1.7.6 returning the statistics using a Promise.` where it shows what the `result` format should be coming out of a `mapReduce` Promise
#### Aggregate

http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#aggregate

New Promise syntax requires a `.toArray()` call for `collection.aggregate`
